### PR TITLE
Altered '/' chat commands to make wildcard more accurate

### DIFF
--- a/public/assets/js/dubtrack/src/views/chat/chat.view.js
+++ b/public/assets/js/dubtrack/src/views/chat/chat.view.js
@@ -518,7 +518,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			tmpstr;
 
 
-		if(message.indexOf("/kick @") !== -1){
+		if(message.indexOf("/kick @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -528,7 +528,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/ban @") !== -1){
+		if(message.indexOf("/ban @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -538,7 +538,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/unban @") !== -1){
+		if(message.indexOf("/unban @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -548,7 +548,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/setmod @") !== -1){
+		if(message.indexOf("/setmod @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -558,7 +558,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/unsetmod @") !== -1){
+		if(message.indexOf("/unsetmod @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -568,7 +568,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/unmute @") !== -1){
+		if(message.indexOf("/unmute @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -578,7 +578,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/mute @") !== -1){
+		if(message.indexOf("/mute @") === 0){
 			tmpstr = message.replace(/(@[A-Za-z0-9_.]+)/g, function(str){
 				username = str.replace("@", "");
 				return str;
@@ -588,7 +588,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 			return;
 		}
 
-		if(message.indexOf("/skip") !== -1){
+		if(message.indexOf("/skip") === 0){
 			this.skipSong();
 			return;
 		}


### PR DESCRIPTION
So we had noticed that the / commands available in chat would trigger if you posted the wildcard in the middle of a message. 

More specifically, sending the message 'foo bar google.com/skipit foo' would skip the current track.

This is due to the if statements in sendMessage( ), which looked for ' indexOf !== -1 ' , which resolves to 'If [wildcard] exists in message'. Changed it to === 0, which is what is returned by indexOf when the substring is at the beginning of the word. 

Hope its ok if we contribute!! :)