### PR TITLE
Fix for long room title names above chat

### DIFF
--- a/public/assets/js/dubtrack/src/views/room/avatar.view.js
+++ b/public/assets/js/dubtrack/src/views/room/avatar.view.js
@@ -60,7 +60,7 @@ Dubtrack.View.roomUsers = Backbone.View.extend({
 
 		this.loadingEl = this.$el.find(".loadingAva");
 
-		this.$('a.loadRoomAva').html('<i>' + this.model.get('name') + '</i><span>chat</span>');
+		this.$('a.loadRoomAva').html('<span>chat</span><div title="' + this.model.get('name') + '">' + this.model.get('name') + '</div>');
 
 		this.currentTabEl.css("width", "100%");
 

--- a/public/assets/scss/room/_users.scss
+++ b/public/assets/scss/room/_users.scss
@@ -119,10 +119,14 @@
 					display: block;
 				}
 
-				i{
+				div{
 					font-style: normal;
 					font-size: 0.7em;
 					@include opacity(0.5);
+					width: 26em;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
 				}
 
 				span{


### PR DESCRIPTION
Refers to #78 

Add title attribute so full title can be read on hover, change room name to div instead of i to set a width for overflow, changed order for span to be first in `.loadRoomAva` since that is how it is displayed

An example of this is in action:
http://puu.sh/kA1n9/84849cbbfa.png
