### PR TITLE
clean up match, add more giphy

### DIFF
--- a/public/assets/js/dubtrack/src/config.js
+++ b/public/assets/js/dubtrack/src/config.js
@@ -665,7 +665,7 @@ w.Dubtrack = {
 
 		text : {
 			convertHtmltoTags: function(text, imagloadFun){
-				var imageRegex = /^((http|https)\:\/\/(i\.imgur\.com|img[0-9]{2}\.deviantart\.net|media\.giphy\.com|[0-9]{2}\.media\.tumblr\.com|s-media-cache-ak[0-9]\.pinimg\.com|reactiongifs\.com))(.*)\.(png|jpg|jpeg|gif)$/;
+				var imageRegex = /^(https?\:\/\/(i\.imgur\.com|img[0-9]{2}\.deviantart\.net|media[0-9]?\.giphy\.com|[0-9]{2}\.media\.tumblr\.com|s-media-cache-ak[0-9]\.pinimg\.com|reactiongifs\.com))(.*)\.(png|jpg|jpeg|gif)$/;
 
 				text = text.replace(/(\b(?:https?|ftp):\/\/[a-z0-9-+&@#\/%()[\]?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|])/gim,
 					function(str) {


### PR DESCRIPTION
giphy addresses are often mediaX.giphy.com, where X is a single digit. This matches those as well. Also, there's need to repeat the 'http' in the initial match.
