### PR TITLE
The volume slider is linear, should be logarithmic

### DIFF
--- a/public/assets/js/dubtrack/src/views/base/playerController.view.js
+++ b/public/assets/js/dubtrack/src/views/base/playerController.view.js
@@ -230,6 +230,9 @@ Dubtrack.View.PlayerController = Backbone.View.extend({
 	},
 
 	setVolume: function(value){
+    // gives the slider a logarithmic scale for adjustment instead of linear
+    if( value != 0 )
+        value = ( ( Math.pow(n, 2) / 10000 /* Math.pow(100, 2) */ ) * 97 ) + 3
 		Dubtrack.helpers.cookie.set('dubtrack-room-volume', value, 30);
 		this.volume = value;
 

--- a/public/assets/js/dubtrack/src/views/base/playerController.view.js
+++ b/public/assets/js/dubtrack/src/views/base/playerController.view.js
@@ -230,9 +230,9 @@ Dubtrack.View.PlayerController = Backbone.View.extend({
 	},
 
 	setVolume: function(value){
-    // gives the slider a logarithmic scale for adjustment instead of linear
-    if( value != 0 )
-        value = ( ( Math.pow(n, 2) / 10000 /* Math.pow(100, 2) */ ) * 97 ) + 3
+		// gives the slider a logarithmic scale for adjustment instead of linear
+		if( value != 0 )
+				value = ( ( Math.pow(n, 2) / 10000 /* Math.pow(100, 2) */ ) * 97 ) + 3
 		Dubtrack.helpers.cookie.set('dubtrack-room-volume', value, 30);
 		this.volume = value;
 


### PR DESCRIPTION
Perception of sound is on a logarithmic scale. That's why dropping the volume from 100% -> 50% currently sounds like the same reduction in sound as dropping it from 50% -> 25%. This should address that. 

Some notes: I noticed that if the value of Dubtrack.playerController.volume is anything less than 3, the sound will become muted. That's why I'm altering the volume on a range of 0-97 and adding 3. You can recreate this easily by typing the following in your console:

Dubtrack.room.player.setVolume(2.9)

It takes about 5 second to update, but this should mute the room. Tested in Chrome and IE Edge. Calling setVolume with a value of 3 will resume audio. 
