### PR TITLE
Shorten url

### DIFF
--- a/public/assets/js/dubtrack/src/config.js
+++ b/public/assets/js/dubtrack/src/config.js
@@ -705,7 +705,7 @@ w.Dubtrack = {
 							str = '<a href="' + str + '" class="autolink" target="_blank"><img src="' + str + '" alt="' + str + '" onload="' + imagloadFun + '" onerror="' + onErrorAction + '" /></a>';
 							return str;
 						} else {
-							str = '<a href="' + str + '" class="autolink" target="_blank">' + shortenLink(str, 140) + '</a>';
+							str = '<a href="' + str + '" class="autolink" target="_blank">' + shortenLink(str, 60) + '</a>';
 							return str;
 						}
 				});

--- a/public/assets/js/dubtrack/src/config.js
+++ b/public/assets/js/dubtrack/src/config.js
@@ -682,6 +682,18 @@ w.Dubtrack = {
 		},
 
 		text : {
+
+			shortenLink: function(displayLink, maxLimit) {
+				if(displayLink.length > maxLimit) {
+					displayLink = displayLink.substring(0, maxLimit) + "...";
+				}
+				return displayLink;
+			},
+
+			shortenMessage: function(text, maxLimit) {
+				return text.substring(0, maxLimit);
+			},
+
 			convertHtmltoTags: function(text, imagloadFun){
 				var imageRegex = /^((http|https)\:\/\/(i\.imgur\.com|img[0-9]{2}\.deviantart\.net|media[0-9]?\.giphy\.com|[0-9]{2}\.media\.tumblr\.com|s-media-cache-ak[0-9]\.pinimg\.com|(www\.)?reactiongifs\.com|9gag\.com|upload\.wikimedia\.org))(.*)\.(png|jpg|jpeg|gif)$/;
 
@@ -693,7 +705,7 @@ w.Dubtrack = {
 							str = '<a href="' + str + '" class="autolink" target="_blank"><img src="' + str + '" alt="' + str + '" onload="' + imagloadFun + '" onerror="' + onErrorAction + '" /></a>';
 							return str;
 						} else {
-							str = '<a href="' + str + '" class="autolink" target="_blank">' + str + '</a>';
+							str = '<a href="' + str + '" class="autolink" target="_blank">' + shortenLink(str, 140) + '</a>';
 							return str;
 						}
 				});

--- a/public/assets/js/dubtrack/src/utils/util.js
+++ b/public/assets/js/dubtrack/src/utils/util.js
@@ -485,7 +485,7 @@ Dubtrack.els.templates = {
 									'<div id="new-messages-counter"><span class="messages-display"></span> <i class="icon-arrow-down2"></i>' +
 									'</div>' +
 									'<% if(Dubtrack.loggedIn) { %>' +
-										'<input id="chat-txt-message" name="message" type="text" placeholder= "'+ dubtrack_lang.chat.type_message +'" autocomplete="off" maxlength="140">' +
+										'<input id="chat-txt-message" name="message" type="text" placeholder= "'+ dubtrack_lang.chat.type_message +'" autocomplete="off">' +
 										'<span class="icon-camera"></span>' +
 										'<button class= "pusher-chat-widget-send-btn">' +
 											'<span class="icon-arrow-right2"></span>' +

--- a/public/assets/js/dubtrack/src/views/chat/chatItem.view.js
+++ b/public/assets/js/dubtrack/src/views/chat/chatItem.view.js
@@ -11,7 +11,7 @@ Dubtrack.View.chatItem = Backbone.View.extend({
 	initialize:function () {
 		this.model.set( 'message', Dubtrack.helpers.text.convertHtmltoTags( this.model.get('message'), "Dubtrack.room.chat.scollBottomChat();" ));
 		this.model.set( 'message', Dubtrack.helpers.text.convertAttoLink( this.model.get('message') ));
-		this.model.set( 'message', Dubtrack.helpers.text.shortenMessage( this.model.get('message'), 140));
+		this.model.set( 'message', Dubtrack.helpers.text.shortenMessage( this.model.get('message'), 300));
 		this.model.bind('change', this.setId, this);
 
 		var modelJson = this.model.toJSON();

--- a/public/assets/js/dubtrack/src/views/chat/chatItem.view.js
+++ b/public/assets/js/dubtrack/src/views/chat/chatItem.view.js
@@ -11,6 +11,7 @@ Dubtrack.View.chatItem = Backbone.View.extend({
 	initialize:function () {
 		this.model.set( 'message', Dubtrack.helpers.text.convertHtmltoTags( this.model.get('message'), "Dubtrack.room.chat.scollBottomChat();" ));
 		this.model.set( 'message', Dubtrack.helpers.text.convertAttoLink( this.model.get('message') ));
+		this.model.set( 'message', Dubtrack.helpers.text.shortenMessage( this.model.get('message'), 140));
 		this.model.bind('change', this.setId, this);
 
 		var modelJson = this.model.toJSON();


### PR DESCRIPTION
Hey I just joined your awesome site! Thank you for making this.

I'm not a Javascript expert, or the best UX guy, but I noticed when I tried to paste a URL that was greater than 140 characters in the chat, it truncated and broke the link.

One solution : User uses bit.ly or a URL shortener.

My idea:
- 60 character limit displaying HTML links (URL remains intact though, just link text)
  - Remove max-length on the client end, and truncate in the view a greater limit of 300.

Tell me what you think. I can see a problem with the unpredictable truncations, people not expecting what they pasted in to be truncated, etc. So maybe this isn't even a solvable problem?? 
- This code has not been tested, and should be reviewed
