### PR TITLE
Fixed playlist link not directing to right page

### DIFF
--- a/public/assets/js/dubtrack/src/utils/util.js
+++ b/public/assets/js/dubtrack/src/utils/util.js
@@ -894,7 +894,7 @@ Dubtrack.els.templates = {
 									'</li>' +
 									'<% if(Dubtrack.loggedIn) {%>'+
 										'<li class="playlist remove-if-banned">' +
-											'<a href="/browser" class="navigate">' +
+											'<a href="/browser/room-queue" class="navigate">' +
 												'<span class="icon-list"></span>' +
 											'</a>' +
 										'</li>' +


### PR DESCRIPTION
Currently the playlist button acts as a link to whichever menu you were last in in the playlist browser. AFAIK it's supposed to take you to the room's queue instead, since the other two buttons link to the two other playlist menus. This fixes it so you now have a button for each of the three menus.
