### PR TITLE
Queue position info in footer

### DIFF
--- a/public/assets/js/dubtrack/src/utils/util.js
+++ b/public/assets/js/dubtrack/src/utils/util.js
@@ -746,6 +746,9 @@ Dubtrack.els.templates = {
 										'<li class="display-browser remove-if-banned">' +
 											'<a class="display-browser">' +
 												'<span class="icon-playlist"></span>' +
+												'<span class="queue-position"></span>' +
+												'<span class="queue-position-split">/</span>' +
+												'<span class="queue-total"></span>' +
 											'</a>' +
 										'</li>' +
 										'<li class="add-to-playlist remove-if-banned remove-if-iframe">' +

--- a/public/assets/js/dubtrack/src/views/room/player.view.js
+++ b/public/assets/js/dubtrack/src/views/room/player.view.js
@@ -46,8 +46,8 @@ Dubtrack.View.Player = Backbone.View.extend({
 		this.customEmbedIframeErrorDiv = this.$('#custom_iframe_embed_error');
 
 		var activeQueueUrl = Dubtrack.config.urls.roomPlaylist.replace( ":id", this.model.id );
-		this.actveQueueCollection = new Dubtrack.Collection.RoomActiveQueue();
-		this.actveQueueCollection.url = Dubtrack.config.apiUrl + activeQueueUrl;
+		this.activeQueueCollection = new Dubtrack.Collection.RoomActiveQueue();
+		this.activeQueueCollection.url = Dubtrack.config.apiUrl + activeQueueUrl;
 
 		Dubtrack.Events.bind('realtime:room-update', this.roomUpdate, this);
 
@@ -432,12 +432,12 @@ Dubtrack.View.Player = Backbone.View.extend({
 		this.queueInfo.empty().removeClass('queue-active');
 
 		//get room active queu
-		this.actveQueueCollection.fetch({
+		this.activeQueueCollection.fetch({
 			reset: true,
 
 			success : function(){
 				var queueCounter = 0;
-				_.each(this.actveQueueCollection.models, function(activeQueueItem){
+				_.each(this.activeQueueCollection.models, function(activeQueueItem){
 					queueCounter++;
 
 					if(Dubtrack.session.id == activeQueueItem.get('userid')){

--- a/public/assets/styl/components/player-controller.styl
+++ b/public/assets/styl/components/player-controller.styl
@@ -123,8 +123,8 @@
 						span
 							margin 0 .1rem
 							
-							&.queue-position
-								margin-left 0.3rem
+							&.icon-playlist
+								margin-right 0.3rem
 
 							&.queue-position-split
 								display none
@@ -139,7 +139,8 @@
 
 				.dub-counter
 					margin-left 0.5rem
-					display relative
+					display inline-block
+					position relative
 					top -0.1rem
 
 				.dubdown

--- a/public/assets/styl/components/player-controller.styl
+++ b/public/assets/styl/components/player-controller.styl
@@ -20,8 +20,8 @@
 		background $background-primary-color
 
 		@media screen and (min-width: $desktop-breakpoint)
+			width 80%
 			top 3rem
-			padding-right 20.7rem
 			position static
 
 		.custom-embed-info
@@ -91,7 +91,7 @@
 		width 100%
 
 		@media screen and (min-width: $desktop-breakpoint)
-			width auto
+			width 20% //TODO: May need to up this to 25% when grab count is added
 
 		ul
 			li
@@ -102,21 +102,45 @@
 				font-weight bold
 				cursor pointer
 				width 25%
+			
+				//TODO: Remove when grab count is added
+				&.add-to-playlist
+					@media screen and (min-width: $desktop-breakpoint)
+						width 16%
+						text-align center
 
 				@media screen and (min-width: $desktop-breakpoint)
-					width auto
+					 width 28%
+				//end remove
 
 				a
-					padding 1rem 1.5rem
+					padding 1rem 1rem
 					display block
 					text-align center
+					
+					&.display-browser
+						
+						span
+							margin 0 .1rem
+							
+							&.queue-position
+								margin-left 0.3rem
+
+							&.queue-position-split
+								display none
+						
+						[class^="queue-"]
+						[class*=" queue-"]
+							position relative
+							top -0.1rem
 
 				&:before
 					font-size 1.2rem
 
 				.dub-counter
 					margin-left 0.5rem
-					display inline-block
+					display relative
+					top -0.1rem
 
 				.dubdown
 				.dubup


### PR DESCRIPTION
- Add queue position and total next to footer playlist button
- Redesign footer using percentages rather than padding
- Fix spelling in player view

I added some notes in the footer's styling to where the percentages will need to change when grab count is added.
### Desktop
#### No one queued:

![http://puu.sh/lSra6/bc3409256f.png](http://puu.sh/lSra6/bc3409256f.png)
#### Not queued:

![http://puu.sh/lSr7H/96985eac11.jpg](http://puu.sh/lSr7H/96985eac11.jpg)
#### Smaller queue:

![http://puu.sh/lSqj5/21a95dd66a.jpg](http://puu.sh/lSqj5/21a95dd66a.jpg)
#### Bigger queue:

![http://puu.sh/lSqgl/1e172f30c5.jpg](http://puu.sh/lSqgl/1e172f30c5.jpg)
### Mobile
#### No one queued:

![http://puu.sh/lSrc2/86916bd728.png](http://puu.sh/lSrc2/86916bd728.png)
#### Not queued:

![http://puu.sh/lSr47/8388bf105b.png](http://puu.sh/lSr47/8388bf105b.png)
#### Smaller queue:

![http://puu.sh/lSqQi/ffd075de29.png](http://puu.sh/lSqQi/ffd075de29.png)
#### Bigger queue:

![http://puu.sh/lSqqM/0e4f559d1e.png](http://puu.sh/lSqqM/0e4f559d1e.png)
