### PR TITLE
Added hidden video icon at the center of the player

### DIFF
--- a/public/assets/styl/components/player.styl
+++ b/public/assets/styl/components/player.styl
@@ -164,6 +164,20 @@
 			top 0
 			left 0
 
+			&::before
+				visibility visible
+				cursor default
+				font-family icomoon
+				content "\e90a"
+				position absolute
+				top 50%
+				left 50%
+				transform translate(-50%,-50%)
+				line-height 1
+				color #ccc
+				opacity .33
+				font-size 160px
+
 			#room-main-player-container-youtube
 			#room-main-player-container-soundcloud
 				position absolute


### PR DESCRIPTION
I did this awhile ago, but just now I could finally add to Dubtrack code.
Basically I added the icon of the button to hide the video at the center of the player, so it displays when the video is hidden.
### Before

![Before](http://i.imgur.com/qozptEL.png)
### After

![After](http://i.imgur.com/5II215P.png)
