### PR TITLE
Guest count on users tab

### DIFF
--- a/public/assets/js/dubtrack/src/utils/util.js
+++ b/public/assets/js/dubtrack/src/utils/util.js
@@ -405,7 +405,10 @@ Dubtrack.els.templates = {
 		'chatContainer': //'	<a href="#" class="chat-commands">?</a>' +
 							'<div class="chat_tools">' +
 								'<span class="display-chat icon-chat active"></span>' +
-								'<span class="display-room-users icon-people"><i class="room-user-counter"></i></span>' +
+								'<span class="display-room-users icon-people">' +
+									'<i class="room-user-counter"></i>' +
+									'<i class="room-guest-counter"></i>' +
+								'</span>' +
 								'<span class="display-chat-settings icon-chatsettings"></span>' +
 							'</div>' +
 							'<div class="chat-options">' +

--- a/public/assets/js/dubtrack/src/views/chat/chat.view.js
+++ b/public/assets/js/dubtrack/src/views/chat/chat.view.js
@@ -154,6 +154,8 @@ Dubtrack.View.chat = Backbone.View.extend({
 	displayRoomUsers: function(){
 		if(Dubtrack.room && Dubtrack.room.$el){
 			Dubtrack.room.$el.removeClass('display-chat-settings').addClass('display-users-rooms');
+			Dubtrack.room.$el.find('.chat_tools').find('.active').removeClass('active');
+			Dubtrack.room.$el.find('.icon-people').addClass('active');
 
 			if(Dubtrack.room && Dubtrack.room.users) Dubtrack.room.users.resetEl();
 		}
@@ -164,6 +166,8 @@ Dubtrack.View.chat = Backbone.View.extend({
 	displayChat: function(){
 		if(Dubtrack.room && Dubtrack.room.$el){
 			Dubtrack.room.$el.removeClass('display-users-rooms display-chat-settings');
+			Dubtrack.room.$el.find('.chat_tools').find('.active').removeClass('active');
+			Dubtrack.room.$el.find('.icon-chat').addClass('active');
 		}
 
 		return false;
@@ -172,6 +176,8 @@ Dubtrack.View.chat = Backbone.View.extend({
 	displayChatOptions: function(){
 		if(Dubtrack.room && Dubtrack.room.$el){
 			Dubtrack.room.$el.removeClass('display-users-rooms').addClass('display-chat-settings');
+			Dubtrack.room.$el.find('.chat_tools').find('.active').removeClass('active');
+			Dubtrack.room.$el.find('.icon-chatsettings').addClass('active');
 		}
 
 		return false;
@@ -947,6 +953,11 @@ Dubtrack.View.chat = Backbone.View.extend({
 	setUserCount: function(users){
 		this.$('.room-user-counter').html(users);
 		$('.mobile-users-counter').html(users);
+	},
+
+	setGuestCount: function(users){
+		this.$('.room-guest-counter').html(users);
+		$('.mobile-guests-counter').html(users);
 	},
 
 	skipSong: function(){

--- a/public/assets/js/dubtrack/src/views/room/avatar.view.js
+++ b/public/assets/js/dubtrack/src/views/room/avatar.view.js
@@ -90,6 +90,8 @@ Dubtrack.View.roomUsers = Backbone.View.extend({
 
 			if(Dubtrack.room && Dubtrack.room.chat){
 				Dubtrack.room.chat.setUserCount(this.rt_users.length);
+				var guestCount = this.uuids.length - this.rt_users.length;
+				Dubtrack.room.chat.setGuestCount(guestCount >= 0 ? guestCount : 0);
 			}
 		});
 	},

--- a/public/assets/styl/components/chat.styl
+++ b/public/assets/styl/components/chat.styl
@@ -35,14 +35,12 @@
 			color $meta-color
 			position relative
 
-			&:after
-				content ""
-				position absolute
-				border 1px solid $primary-color
-				bottom 0
-				left 0
-				width 100%
-				display none
+			&.active
+				border-bottom 1px solid $primary-color
+				
+				&.icon-people
+					.room-guest-counter
+						color: $meta-color !important
 
 			&.display-chat
 				color $primary-color
@@ -51,7 +49,11 @@
 					display block
 
 			&:hover
-				color $primary-color
+				color $primary-color !important
+				
+				&.icon-people
+					.room-guest-counter
+						color $meta-color
 
 			&.icon-chatsettings
 				font-size 2.5rem
@@ -59,13 +61,20 @@
 
 			&.icon-people
 				i
-					font-size 0.85rem
+					font-size 0.95rem
 					line-height 0.8
 					font-style normal
 					font-weight bold
 					margin-left 0.4rem
-					top -0.3rem
+					top: -0.75rem;
+					left: 0.1rem;
 					position relative
+					
+					&.room-guest-counter
+						top: 0.1rem;
+						left: -0.7rem;
+						font-size: 0.85rem;
+						color: $dark-gray
 
 	.chatLoading
 		display none


### PR DESCRIPTION
Add guest count under user count above chat, fixed issue where spans above chat wouldn't have a hover effect when anything other than chat was selected

Also fixed hover css error where there would be no hover effect for tabs if anything but chat was active

![http://i.imgur.com/IGGpkv8.gif](http://i.imgur.com/IGGpkv8.gif)
