### PR TITLE
Added Soundcloud Icon to Soundcloud player.

### DIFF
--- a/public/assets/js/dubtrack/src/views/room/delegateViews/soundcloud.js
+++ b/public/assets/js/dubtrack/src/views/room/delegateViews/soundcloud.js
@@ -38,7 +38,7 @@ Dubtrack.View.SoundCloudPlayer = Backbone.View.extend({
 			id: this.id
             
             
-		}).html('<img src="'+this.renderSC()+'" alt="" />')
+		}).html('<img class="artwork" src="'+this.renderSC()+'" alt="" />')
 		.css({
 			'position': 'absolute',
 			'top': 0,
@@ -95,6 +95,20 @@ Dubtrack.View.SoundCloudPlayer = Backbone.View.extend({
 				});
 			}
 		});
+
+		var $el = this.$el, req = new XMLHttpRequest();
+		req.open(
+			'GET',
+			'https://api.soundcloud.com/tracks/' + Dubtrack.room.player.activeSong.get('songInfo').fkid + '?consumer_key=' + Dubtrack.config.keys.soundcloud,
+			false
+		);
+		req.onreadystatechange = function() {
+			if(req.readyState !== 4) return;
+			var permalink = req.responseText.match(/"permalink_url":"(.[^"]+)"/g);
+				permalink = permalink[1].match(/http(s|)\:\/\/.+/);
+			$('<a href="' + permalink + '" target="_blank"><span class="soundcloud_watermark icon-soundcloud"></span></a>').appendTo($el);
+		};
+		req.send();
 
 		return this;
 	},

--- a/public/assets/styl/components/player.styl
+++ b/public/assets/styl/components/player.styl
@@ -187,21 +187,41 @@
 				left 0
 				z-index 10
 
-			.playerElement
-				position relative
-				width 100%
-				height 100%
+				.playerElement
+					position relative
+					width 100%
+					height 100%
 
-				&.soundcloud
-					img
-						position inherit
-						height 100%
-						width 56%
-						top: 50%
-						transform translateY(-50%)
-						transform-style preserve-3d
-						backface-visibility hidden
-						left: 22%
+					&.soundcloud
+						.artwork
+							position inherit
+							height 100%
+							width 56%
+							top: 50%
+							transform translateY(-50%)
+							transform-style preserve-3d
+							backface-visibility hidden
+							left: 22%
+
+						.soundcloud_watermark
+							position absolute
+							bottom 12px
+							right 12px
+							font-size 60px
+							font-size 3.75rem
+							color #eee
+							text-shadow 0 0 1px #808080
+							opacity 0
+							transition opacity .20s
+							z-index 22
+              
+						&:hover
+							.soundcloud_watermark
+								opacity .75
+								
+								&:hover
+									opacity 1
+									transition opacity .10s
 
 	#custom_iframe_embed
 		display none


### PR DESCRIPTION
Ref to [Issue #229](https://github.com/dubtrack/www-dubtrack-fm/issues/229)

The icon appears at the bottom right of the player when Soundcloud songs are playing. When clicked, it links to the soundcloud permalink of the current song, similar to YouTube's Watermark.

For this, I had to request to the Soundcloud API (which was really hard considering how bad it responds) but it would be a lot better if the permalink was included inside the song object

![Image showing feature](http://i.imgur.com/tLtoTNT.gif)
