### PR TITLE
Ignore case when checking if user is @mentioned

### DIFF
--- a/public/assets/js/dubtrack/src/views/chat/chat.view.js
+++ b/public/assets/js/dubtrack/src/views/chat/chat.view.js
@@ -637,7 +637,7 @@ Dubtrack.View.chat = Backbone.View.extend({
 				}
 
 				if(Dubtrack.session && Dubtrack.session.get('username')){
-					var regex = new RegExp("@" + Dubtrack.session.get('username') + "\\b", 'g');
+					var regex = new RegExp("@" + Dubtrack.session.get('username') + "\\b", 'i');
 					var mention = regex.test(chatModel.get('message'));
 					this.playSound(mention);
 				}else{


### PR DESCRIPTION
Ignore lower/upper case when checking if a new message @mentions the user; this currently only affects whether a mention sound is played or not. This fixes #248. E.g. with this change, a message with "@example" will trigger a notification sound for a user "eXampLe".

(i also removed the global regexp flag, because it's not needed here, as we are only testing if the message contains _any_ @mention for the current user)
