### PR TITLE
improve readability of usernames in chat

### DIFF
--- a/public/assets/styl/components/chat.styl
+++ b/public/assets/styl/components/chat.styl
@@ -141,7 +141,7 @@
 							word-wrap break-word
 
 							.username-handle
-								font-weight bold
+								text-shadow 0 1px 0px
 
 							img
 								max-width 100%
@@ -162,8 +162,8 @@
 								display block
 								font-size 0.9rem
 								line-height 1.2
-								font-weight bold
 								color $meta-color
+								text-shadow 0 1px 0px, 0 1px 0px
 								cursor pointer
 
 					.meta-info


### PR DESCRIPTION
This makes the "i" and "l" distinguishable in usernames and @mentions in the chat, without having to change the font (-family). It creates a fake bold effect by adding a non-blurry text-shadow, that will adapt to the current text colour (so it should work for script users with custom styles).

Only conflict I noticed was with how DubX styles the names of admins (it manually adds a gray text-shadow that overrides the one of this commit). But it looks nice anyways, so ¯\_(ツ)_/¯

before:
![](https://i.imgur.com/nHv52KZ.png) ![](https://i.imgur.com/313xArV.png) ![](https://i.imgur.com/4SVxeKu.png)

after:
![](https://i.imgur.com/xYP8Taz.png) ![](https://i.imgur.com/ChFPVM3.png) ![](https://i.imgur.com/kkZvT7C.png)
as you can see, "i"s definitely have an i-dot with this commit, instead of looking like straight lines (like a lowercase L)

It does **not** improve the readability of emotes ( /me messages ) ![](https://i.imgur.com/gFoZxqr.png)
