### PR TITLE
Sync Volume from Room Player to Preview Player

### DIFF
--- a/public/assets/js/dubtrack/src/views/browser/browser.view.js
+++ b/public/assets/js/dubtrack/src/views/browser/browser.view.js
@@ -1844,7 +1844,6 @@ Dubtrack.View.PreivewEl = Backbone.View.extend({
 			default:
 			break;
 		}
-
 	},
 
 	closeAction : function(){

--- a/public/assets/js/dubtrack/src/views/browser/browser.view.js
+++ b/public/assets/js/dubtrack/src/views/browser/browser.view.js
@@ -1863,6 +1863,9 @@ Dubtrack.View.PreivewEl = Backbone.View.extend({
 	buildSoundCloud : function(){
 		this.player = new scDubsPlayerView();
 		this.player_container.append( this.player.render(this.model.get('streamUrl'), this.id + "_audio", this.model.get('type'), true ).$el );
+		if (Dubtrack.playerController.volume) {
+			this.player.setVolume(Dubtrack.playerController.volume);
+		}
 	},
 
 	loadComments : function(){},

--- a/public/assets/js/dubtrack/src/views/browser/browser.view.js
+++ b/public/assets/js/dubtrack/src/views/browser/browser.view.js
@@ -1844,6 +1844,7 @@ Dubtrack.View.PreivewEl = Backbone.View.extend({
 			default:
 			break;
 		}
+
 	},
 
 	closeAction : function(){
@@ -1853,8 +1854,10 @@ Dubtrack.View.PreivewEl = Backbone.View.extend({
 	buildYT : function(){
 		this.player = new ytDubsPlayerView();
 		this.player_container.append( this.player.render(this.id, this.id + "_video").$el );
-
 		this.player.buildPlayer(true);
+		if (Dubtrack.playerController.volume) {
+			this.player.setVolume(Dubtrack.playerController.volume);
+		}
 	},
 
 	buildSoundCloud : function(){

--- a/public/assets/js/dubtrack/src/views/dubs/delegateViews/soundcloud.dubs.js
+++ b/public/assets/js/dubtrack/src/views/dubs/delegateViews/soundcloud.dubs.js
@@ -13,7 +13,6 @@ scDubsPlayerView = Backbone.View.extend({
 
 	initialize : function(){
 
-
 	},
 
 	render : function(url, id, type, autoPlay, $w, $h){
@@ -61,7 +60,6 @@ scDubsPlayerView = Backbone.View.extend({
 				self.loadingEl.hide();
 				self.playEl.css("display", "block");
 
-
 				//create sound with sound manager
 				self.scPlayer = soundManager.createSound({
 					id: id,
@@ -97,7 +95,6 @@ scDubsPlayerView = Backbone.View.extend({
 						}
 					}
 				});
-
 			}
 		});
 

--- a/public/assets/js/dubtrack/src/views/dubs/delegateViews/soundcloud.dubs.js
+++ b/public/assets/js/dubtrack/src/views/dubs/delegateViews/soundcloud.dubs.js
@@ -13,6 +13,7 @@ scDubsPlayerView = Backbone.View.extend({
 
 	initialize : function(){
 
+
 	},
 
 	render : function(url, id, type, autoPlay, $w, $h){
@@ -60,6 +61,7 @@ scDubsPlayerView = Backbone.View.extend({
 				self.loadingEl.hide();
 				self.playEl.css("display", "block");
 
+
 				//create sound with sound manager
 				self.scPlayer = soundManager.createSound({
 					id: id,
@@ -95,6 +97,7 @@ scDubsPlayerView = Backbone.View.extend({
 						}
 					}
 				});
+
 			}
 		});
 
@@ -152,9 +155,6 @@ scDubsPlayerView = Backbone.View.extend({
 			this.scPlayer.play();
 		}
 	},
-	setVolume : function(vol){
-		if(this.scPlayer) this.scPlayer.setVolume(parseInt(vol));
-	},
 
 	buildVolume : function(){
 		var slider  = this.volumeContainer.find('.volume-control'),
@@ -208,9 +208,11 @@ scDubsPlayerView = Backbone.View.extend({
 	},
 
 	setVolume : function (newVolume) {
+		var volume = parseInt(newVolume);
 		if(this.scPlayer){
 			this.scPlayer.unmute();
-			this.scPlayer.setVolume(parseInt(newVolume));
+			this.volumeContainer.find('.volume-control').slider('value', volume);
+			this.scPlayer.setVolume(volume);
 		}
 	},
 

--- a/public/assets/js/dubtrack/src/views/dubs/delegateViews/youtube.dubs.js
+++ b/public/assets/js/dubtrack/src/views/dubs/delegateViews/youtube.dubs.js
@@ -22,6 +22,7 @@ var ytDubsPlayerView = Backbone.View.extend({
 		this.playerEl = $('<div/>', { id : id }).appendTo( el );
 		this.videoId = videoId;
 		this.replayEl.hide();
+		this.volume = 100;
 
 		this.mainYTimg = $('<div/>', {'class' : 'playerImage'}).html('<img src="http://img.youtube.com/vi/' + videoId + '/0.jpg" alt="">').appendTo( el );
 
@@ -58,7 +59,8 @@ var ytDubsPlayerView = Backbone.View.extend({
 								if(self.intervalLoaded) clearTimeout(self.intervalLoaded);
 								self.updateytplayerloaded();
 								self.pause();
-
+								self.player.setVolume(self.volume)
+								self.volumeContainer.find('.volume-control').slider('value', self.volume);
 								if(autoplay) self.play();
 							},
 				'onStateChange': function(newState){
@@ -231,8 +233,8 @@ var ytDubsPlayerView = Backbone.View.extend({
 	},
 
 	setVolume : function (newVolume) {
-		if(this.player){
-			this.player.unMute();
+		this.volume = newVolume;
+		if(this.player.setVolume){
 			this.player.setVolume( newVolume );
 		}
 	},


### PR DESCRIPTION
Hi all, this is my first PR for this project. Please let me know what you think and how things go around here. Thanks!
- Added or augmented setVolume on both Youtube and Soundcloud players.
- In Youtube player, needed to add `this.volume` to save any volume settings before player is initialized. Once initialized and "ready" it sets Youtube player to `this.volume`.
- Soundcloud player was more forgiving on setting volume for a sound is initialized on SoundManager
- Added setting slider value to the volume level

Based off Issue #286 for fixing preview volume behavior enhancement.
